### PR TITLE
Closes #7457

### DIFF
--- a/docs/source/cache.mdx
+++ b/docs/source/cache.mdx
@@ -23,6 +23,14 @@ The default 🤗 Datasets cache directory is `~/.cache/huggingface/datasets`. Ch
 $ export HF_HOME="/path/to/another/directory/datasets"
 ```
 
+## HF_DATASETS_CACHE
+
+In addition to using `HF_HOME`, you can override the default 🤗 Datasets cache directory by setting the `HF_DATASETS_CACHE` environment variable. This variable allows you to specify a custom cache location for datasets converted into Arrow format. For instance:
+
+```
+$ export HF_DATASETS_CACHE="/path/to/your/custom/cache"
+```
+
 When you load a dataset, you also have the option to change where the data is cached. Change the `cache_dir` parameter to the path you want:
 
 ```py


### PR DESCRIPTION
This PR updates the documentation to include the HF_DATASETS_CACHE environment variable, which allows users to customize the cache location for datasets—similar to HF_HUB_CACHE for models.